### PR TITLE
Allows using multiple prefixed outputs with same base key

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,37 @@ job = Coconut::Job.create(
 )
 ```
 
+A job without config file can contain outputs with same key (like hls). Since the Hash instance can't have duplicate keys, you have to prefix them:
+
+```ruby
+vid = 1234
+s3 = "s3://accesskey:secretkey@mybucket"
+
+job = Coconut::Job.create(
+  :api_key => "k-api-key",
+  :source  => "http://yoursite.com/media/video.mp4",
+  :webhook => "http://mysite.com/webhook/coconut?videoId=#{vid}",
+  :outputs => {
+    "2@hls" => "#{s3}/videos/playlist.m3u8, variants=hls:360p, if=$source_height > 300",
+    "1@hls" => "#{s3}/videos/playlist.m3u8, variants=hls:240p, if=$source_height < 300",
+  }
+)
+```
+
+The output config file will contain 2 hls outputs, sorted by prefix:
+
+```ini
+var s3 = s3://accesskey:secretkey@mybucket
+
+set webhook = http://mysite.com/webhook/coconut?videoId=$vid
+
+-> hls = $s3/videos/playlist.m3u8, variants=hls:240p, if=$source_height < 300
+-> hls = $s3/videos/playlist.m3u8, variants=hls:360p, if=$source_height > 300
+```
+
+The prefix can be any digital or a-zA-Z char.
+
+
 Note that you can use the environment variable `COCONUT_API_KEY` to set your API key.
 
 ## Contributing

--- a/lib/coconutrb.rb
+++ b/lib/coconutrb.rb
@@ -69,7 +69,7 @@ module Coconut
     new_conf << ""
     new_conf.concat conf.select{|l| l.start_with?("set")}.sort
     new_conf << ""
-    new_conf.concat conf.select{|l| l.start_with?("->")}.sort
+    new_conf.concat conf.select{|l| l.start_with?("->")}.sort.map{ |output| output.sub /^(->\s+)[\w\d]+?@/, '\1' }
 
     return new_conf.join("\n")
   end


### PR DESCRIPTION
 Allows using multiple prefixed outputs with same base key (like hls, dash) in config[:outputs] hash
See README section for more details.